### PR TITLE
Fix gauge refreshing from 0 every value update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ debug.log
 npm-debug.log
 examples/angularjs-gauge.min.js
 examples/angularjs-gauge.min.js.map
+.vs/


### PR DESCRIPTION
Changed gauge behavior to update from the previous point instead of the min. With the change, every time the value changes, it will progress from the previous value (or the min if there ain't one) to the new value.