### PR TITLE
Added fraction size selection

### DIFF
--- a/src/angularjs-gauge.js
+++ b/src/angularjs-gauge.js
@@ -17,7 +17,8 @@
             type: 'full',
             foregroundColor: 'rgba(0, 150, 136, 1)',
             backgroundColor: 'rgba(0, 0, 0, 0.1)',
-            duration: 1500
+            duration: 1500,
+            fractionSize: null
         };
 
         this.setOptions = function (customOptions) {
@@ -35,14 +36,19 @@
         this.$get = function () {
             return ngGauge;
         };
-
     }
 
     gaugeMeterDirective.$inject = ['ngGauge'];
 
     function gaugeMeterDirective(ngGauge) {
 
-        var tpl = '<div style="display:inline-block;text-align:center;position:relative;"><span><u>{{prepend}}</u>{{value | number}}<u>{{append}}</u></span><b>{{label}}</b><canvas></canvas></div>';
+        var tpl = '<div style="display:inline-block;text-align:center;position:relative;">' +
+            '<span><u>{{prepend}}</u>' +
+            '<span ng-if="fractionSize === null">{{value | number}}</span>' +
+            '<span ng-if="fractionSize !== null">{{value | number: fractionSize}}</span>' +
+            '<u>{{append}}</u></span>' +
+            '<b>{{ label }}</b>' +
+            '<canvas></canvas></div>';
 
         var Gauge = function (element, options) {
             this.element = element.find('canvas')[0];
@@ -290,7 +296,8 @@
                 value: '=?',
                 min: '=?',
                 max: '=?',
-                thresholds: '=?'
+                thresholds: '=?',
+                fractionSize: '=?'
 
             },
             link: function (scope, element) {
@@ -306,6 +313,7 @@
                 scope.foregroundColor = angular.isDefined(scope.foregroundColor) ? scope.foregroundColor : defaults.foregroundColor;
                 scope.backgroundColor = angular.isDefined(scope.backgroundColor) ? scope.backgroundColor : defaults.backgroundColor;
                 scope.thresholds = angular.isDefined(scope.thresholds) ? scope.thresholds : {};
+                scope.fractionSize = angular.isDefined(scope.fractionSize) ? scope.fractionSize : defaults.fractionSize;
 
                 var gauge = new Gauge(element, scope);
 
@@ -320,6 +328,7 @@
                 scope.$watch('foregroundColor', watchOther, false);
                 scope.$watch('backgroundColor', watchOther, false);
                 scope.$watch('thresholds', watchData, false);
+                scope.$watch('fractionSize', watchData, false);
 
                 scope.$on('$destroy', function () { });
                 scope.$on('$resize', function () { });


### PR DESCRIPTION
I've added a property called **fraction-size** to allow us to select how many decimals we want to show. I called it fraction-size because it's called like that in angular's [number filter](https://docs.angularjs.org/api/ng/filter/number).
This change also provides localization for the number because it's shown through the "number" filter, that uses angular's selected locale.