### PR TITLE
Add label only mode

### DIFF
--- a/src/angularjs-gauge.js
+++ b/src/angularjs-gauge.js
@@ -17,6 +17,7 @@
             type: 'full',
             foregroundColor: 'rgba(0, 150, 136, 1)',
             backgroundColor: 'rgba(0, 0, 0, 0.1)',
+            labelOnly: false,
             duration: 1500
         };
 
@@ -42,7 +43,7 @@
 
     function gaugeMeterDirective(ngGauge) {
 
-        var tpl = '<div style="display:inline-block;text-align:center;position:relative;"><span><u>{{prepend}}</u>{{value | number}}<u>{{append}}</u></span><b>{{label}}</b><canvas></canvas></div>';
+        var tpl = '<div style="display:inline-block;text-align:center;position:relative;"><span ng-show="{{!labelOnly}}"><u>{{prepend}}</u>{{value | number}}<u>{{append}}</u></span><b>{{label}}</b><canvas></canvas></div>';
 
         var Gauge = function (element, options) {
             this.element = element.find('canvas')[0];
@@ -90,8 +91,8 @@
                     opacity: 0.8
                 });
 
-                var fs = this.options.size / 13;
-                var lh = (5 * fs) + parseInt(this.options.size);
+                var fs = this.options.labelOnly ? lfs * 0.8 : this.options.size / 13;
+                var lh = this.options.labelOnly ? llh : (5 * fs) + parseInt(this.options.size);
 
                 this.legend.css({
                     display: 'inline-block',
@@ -282,6 +283,7 @@
                 cap: '@?',
                 foregroundColor: '@?',
                 label: '@?',
+                labelOnly: '@?',
                 prepend: '@?',
                 size: '@?',
                 thick: '@?',
@@ -303,6 +305,7 @@
                 scope.thick = angular.isDefined(scope.thick) ? scope.thick : defaults.thick;
                 scope.type = angular.isDefined(scope.type) ? scope.type : defaults.type;
                 scope.duration = angular.isDefined(scope.duration) ? scope.duration : defaults.duration;
+                scope.labelOnly = angular.isDefined(scope.labelOnly) ? scope.labelOnly : defaults.labelOnly;
                 scope.foregroundColor = angular.isDefined(scope.foregroundColor) ? scope.foregroundColor : defaults.foregroundColor;
                 scope.backgroundColor = angular.isDefined(scope.backgroundColor) ? scope.backgroundColor : defaults.backgroundColor;
                 scope.thresholds = angular.isDefined(scope.thresholds) ? scope.thresholds : {};

--- a/test/angularjs-gauge.spec.js
+++ b/test/angularjs-gauge.spec.js
@@ -39,6 +39,7 @@ describe('Angular Gauge Unit Test Suites', function () {
         expect(scope.type).toBe('full');
         expect(scope.min).toBe(0);
         expect(scope.max).toBe(100);
+        expect(scope.labelOnly).toBe(false);
     });
 
     it('custom size', function () {
@@ -376,6 +377,24 @@ describe('Angular Gauge Unit Test Suites', function () {
         parentScope.$digest();
         expect(label.text()).toContain("24.898");
         expect(directiveScope.value).toBe(24.8976);
+
+    });
+
+    it("label only supported", function () {
+        var code = "<ng-gauge value='value' min='min' max='max' label='The answer' label-only='true'></ng-gauge>",
+            parentScope = $rootScope.$new();
+
+        parentScope.min = 0;
+        parentScope.max = 100;
+        var elem = $compile(angular.element(code))(parentScope),
+            label = elem.find("span").eq(0),
+            legend = elem.find("b");
+
+        parentScope.value = 42;
+        parentScope.$digest();
+        expect(label.text()).toContain("42");
+        expect(legend.text()).toBe('The answer');
+        expect(label.hasClass('ng-hide')).toBeTruthy();
 
     });
 


### PR DESCRIPTION
The label only mode allow the gauge to be configured so that only the label is displayed.

By default _labelOnly_ has no effects on the directive.

If _labelOnly_ mode is set to _true_ then the value is hidden and the label is drawn as the value in the canvas.

I added a test and I just need to add this option to the documentation. 