### PR TITLE
Fix negative values

### DIFF
--- a/examples/app.js
+++ b/examples/app.js
@@ -36,7 +36,8 @@
       min: 0,
       max: 100,
       foregroundColor: 'rgba(0, 150, 136, 1)',
-      backgroundColor: 'rgba(0, 0, 0, 0.1)'
+      backgroundColor: 'rgba(0, 0, 0, 0.1)',
+      fractionSize: null
     };
 
     vm.thresholds = {

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html ng-app="playground">
 
 <head>
@@ -103,6 +103,10 @@
                 <input type="text" ng-model="m.options.value">
             </md-input-container>
             <md-input-container class="md-block">
+                <label>Fraction size</label>
+                <input type="text" ng-model="m.options.fractionSize">
+            </md-input-container>
+            <md-input-container class="md-block">
                 <label>Label</label>
                 <input ng-model="m.options.label">
             </md-input-container>
@@ -142,7 +146,7 @@
             <div>
                 <ng-gauge type="{{m.options.type}}" size="{{m.options.size}}" thick="{{m.options.thick}}" label="{{m.options.label}}" append="{{m.options.append}}"
                     prepend="{{m.options.prepend}}" cap="{{m.options.cap}}" foreground-color="{{m.options.foregroundColor}}"
-                    background-color="{{m.options.backgroundColor}}" value="m.options.value" min="m.options.min" max="m.options.max"
+                    background-color="{{m.options.backgroundColor}}" value="m.options.value" fraction-size="m.options.fractionSize" min="m.options.min" max="m.options.max"
                     thresholds="m.enableThresholds ? m.thresholds : m.empty"></ng-gauge>
             </div>
         </section>


### PR DESCRIPTION
The value is updated through the $watch on the value property. Having several properties watching over the value was causing the value to update with the old value and new value of the properties attached (different to 'value'). I've changed the $watch to only update the value, any other property should redraw the entire chart.

And I've also added a fallback to the "middle" value to 0, meaning that if the value is undefined, it won't be shown. This can happen if your value is binded after the chart is drawn (like when you wait for an ajax call to retrieve the data).